### PR TITLE
Fix pitch adjust UI duplicating parentheses

### DIFF
--- a/ncursesUtils.c
+++ b/ncursesUtils.c
@@ -41,6 +41,9 @@ void printSamples(audioFile *files, char *fileNames[], int highlightIndex, int n
         if (i == highlightIndex) {
             attron(A_STANDOUT);
         }
+        move(windowHeight + i + 2, 0);
+        clrtoeol();
+
         if (i > 9) {
             mvprintw(windowHeight + i + 2, 1, "%0x: %s (Pitch Adjust: %d)", 
                 i, fileNames[i], files[i].pitchAdjust);


### PR DESCRIPTION
Fixes Issue #9 so that when removing  a digit from the pitch adjust (say, going from 10 to 9), there isn't an extra parenthesis on the end of the line.