### PR TITLE
Improve error reporting in playback.c

### DIFF
--- a/ncursesUtils.c
+++ b/ncursesUtils.c
@@ -56,14 +56,18 @@ void printSamples(audioFile *files, char *fileNames[], int highlightIndex, int n
 }
 
 //You're probably going to need an index
-void sampleError(char* fileName, int windowHeight) {
-    //Clears the area of the screen that indicates which file is bad.
+void sampleError(char* errorMessage, int windowHeight) {
     move(windowHeight - 1, 45);
     clrtoeol();
     attron(A_STANDOUT);
-    char* errorMsg = "--ERROR LOADING FILE--";
-    mvprintw(windowHeight - 2, 45, errorMsg);
-    attron(A_STANDOUT);
-    mvprintw(windowHeight - 1, 45, fileName);
+    mvprintw(windowHeight - 2, 45, "--ERROR--");
+    mvprintw(windowHeight - 1, 45, errorMessage);
     attroff(A_STANDOUT);
+}
+
+void clearErrors(int windowHeight) {
+    move(windowHeight - 1, 45);
+    clrtoeol();
+    move(windowHeight - 2, 45);
+    clrtoeol();
 }

--- a/ncursesUtils.h
+++ b/ncursesUtils.h
@@ -1,6 +1,10 @@
 #ifndef NCURSESUTILS_H
 #define NCURSESUTILS_H
 
+//Window size
+#define DEFAULT_WINDOW_HEIGHT 28
+#define DEFAULT_WINDOW_WIDTH 42
+
 // Ncurses init function
 void initCurses();
 
@@ -16,5 +20,8 @@ void printSamples(audioFile *files, char *fileNames[], int highlightIndex, int n
 
 // Prints an error on a file when stuff goes whack
 void sampleError(char* fileName, int windowHeight);
+
+// Clears sample errors off the screen (used when playing the file again)
+void clearErrors(int windowHeight);
 
 #endif

--- a/playback.c
+++ b/playback.c
@@ -19,6 +19,9 @@
 #include <alloca.h>
 #include "playback.h"
 
+#include <ncurses.h>
+#include "ncursesUtils.h"
+
 #define PCM_DEVICE "default"
 
 void playback(unsigned int rate, int channels, double seconds, int fd){
@@ -43,21 +46,26 @@ void playback(unsigned int rate, int channels, double seconds, int fd){
     /* Set parameters */
     if ((pcm = snd_pcm_hw_params_set_access(pcm_handle, params,
                     SND_PCM_ACCESS_RW_INTERLEAVED)) < 0)
-        printf("ERROR: Can't set interleaved mode. %s\n", snd_strerror(pcm));
+        //printf("ERROR: Can't set interleaved mode. %s\n", snd_strerror(pcm));
+        sampleError("Can't set interleaved mode.", DEFAULT_WINDOW_HEIGHT);
 
     if ((pcm = snd_pcm_hw_params_set_format(pcm_handle, params,
                         SND_PCM_FORMAT_S16_LE)) < 0)
-        printf("ERROR: Can't set format. %s\n", snd_strerror(pcm));
+        //printf("ERROR: Can't set format. %s\n", snd_strerror(pcm));
+        sampleError("Can't set format.", DEFAULT_WINDOW_HEIGHT);
 
     if ((pcm = snd_pcm_hw_params_set_channels(pcm_handle, params, channels)) < 0)
-        printf("ERROR: Can't set channels number. %s\n", snd_strerror(pcm));
+        //printf("ERROR: Can't set channels number. %s\n", snd_strerror(pcm));
+        sampleError("Can't set channels number.", DEFAULT_WINDOW_HEIGHT);
 
     if ((pcm = snd_pcm_hw_params_set_rate_near(pcm_handle, params, &rate, 0)) < 0)
-        printf("ERROR: Can't set rate. %s\n", snd_strerror(pcm));
+        //printf("ERROR: Can't set rate. %s\n", snd_strerror(pcm));
+        sampleError("Can't set rate. ", DEFAULT_WINDOW_HEIGHT);
 
     /* Write parameters */
     if ((pcm = snd_pcm_hw_params(pcm_handle, params)) < 0)
-        printf("ERROR: Can't set harware parameters. %s\n", snd_strerror(pcm));
+        //printf("ERROR: Can't set harware parameters. %s\n", snd_strerror(pcm));
+        sampleError("Can't set hardware parameters. ", DEFAULT_WINDOW_HEIGHT);
 
     /* Resume information */
     //printf("PCM name: '%s'\n", snd_pcm_name(pcm_handle));

--- a/sampleZone.c
+++ b/sampleZone.c
@@ -15,12 +15,9 @@
 #include "playback.h"
 #include "ncursesUtils.h"
 
-#define DEFAULT_WINDOW_HEIGHT 28
-#define DEFAULT_WINDOW_WIDTH 42
 #define WINDOW_OFFSET 1
 #define SAMPLE_MARKERS "0123456789abcdef"
 #define MAX_FILES 16
-#define FILE_NOT_FOUND "File Not Found!"
 
 static int height = DEFAULT_WINDOW_HEIGHT;
 static int width = DEFAULT_WINDOW_WIDTH;
@@ -36,8 +33,7 @@ void *playFile(void *file) {
     wavHeader *header = calloc(1, 44);
     int out = read(fd, header, 44);
     if (out != 44) {
-        //Put sampleError here
-        sampleError(fileName, DEFAULT_WINDOW_HEIGHT);
+        sampleError("Error reading wav header.", DEFAULT_WINDOW_HEIGHT);
         //printf("Error reading wav header\n");
         return NULL;
     }
@@ -68,6 +64,8 @@ audioFile *initFiles(int numFiles, char *fileNames[]) {
 }
 
 void playPattern(WINDOW *win, audioFile *files, int tempo, int numFiles) {
+    // Clear sampleErrors
+    clearErrors(DEFAULT_WINDOW_HEIGHT);
     // Make wgetch a non-blocking call
     nodelay(win, TRUE);
     // Play through grid
@@ -98,7 +96,7 @@ void playPattern(WINDOW *win, audioFile *files, int tempo, int numFiles) {
                 }
 
                 if (fileToPlay > numFiles) {
-                    sampleError(FILE_NOT_FOUND, DEFAULT_WINDOW_HEIGHT);
+                    sampleError("File not found.", DEFAULT_WINDOW_HEIGHT);
                     continue;
                 }
 


### PR DESCRIPTION
Add `sampleError()`s in place of `printfs` in `playback.c` in order to avoid breaking the UI when an error is detected and move a few macros to a header file so they can be accessed in all files that need them.